### PR TITLE
updating link to a copy of the original post

### DIFF
--- a/_posts/2012-01-12-the-secret-to-amazons-success-internal-apis.html
+++ b/_posts/2012-01-12-the-secret-to-amazons-success-internal-apis.html
@@ -6,8 +6,9 @@ image: 'http://kinlane-productions.s3.amazonaws.com/api-evangelist-site/blog/ama
 ---
 
 
-<p>
-     <img style="padding: 15px;" src="http://kinlane-productions.s3.amazonaws.com/amazon/amazon-com-logo.jpg" alt="" align="right" width="225" />Last year there was an <a title="accidental post from a Google employee" href="http://siliconangle.com/furrier/2011/10/12/google-engineer-accidently-shares-his-internal-memo-about-google-platform/">accidental post from a Google employee</a> about Google+.  The internal rant was accidentally shared publicly and provides some insight into how Google approached APIs for their new Google + platform, as well as insight how Amazon adopted an internal service oriented architecture (SOA).
+
+<p>
+     <img style="padding: 15px;" src="http://kinlane-productions.s3.amazonaws.com/amazon/amazon-com-logo.jpg" alt="" align="right" width="225" />Last year there was an <a title="accidental post from a Google employee" href="https://plus.google.com/+RipRowan/posts/eVeouesvaVX">accidental post from a Google employee</a> about Google+.  The internal rant was accidentally shared publicly and provides some insight into how Google approached APIs for their new Google + platform, as well as insight how Amazon adopted an internal service oriented architecture (SOA).
 </p>
 <p>
      The insight about how Google approached the API for Google+ is interesting, but what is far more interesting is the insight the Google engineer who posted the rant, Steve Yegge, provides about his time working at Amazon, before he was a engineer with Google.


### PR DESCRIPTION
This is a really great post of yours, Kin, that I still refer people back to for a TL;DR of the original Google+ post.  

Unfortunately, the link in your post is now dead, so this subs in a link to another copy.  Even though this link is a Google+ link, I believe it'll survive the upcoming shutdown as I don't think that Google is deleting content that people have posted on the service, just now allowing any new content/activity.  

Wishing you the best, friend.  