### PR TITLE
Change h1 to h2 to prevent slight cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ title: API Evangelist
 <section id="banner">
 	<div class="content">
 		<header>
-			<h1><a href="http://101.apievangelist.com">API 101</a></h1>
+			<h2><a href="http://101.apievangelist.com">API 101</a></h2>
 		</header>
 		<p>I have a lot of information regarding APIs on my network of sites, but I'm always trying to make sure I have a sufficient amount of 101, or getting started information for people who are just learning what an API is, and what is possible.</p>
 		<p>I have some information available to help walk you through the concept of an API, and how they have been expanding over the last 15 years across all the online services you have become familiar with on the web and mobile phone.</p>
@@ -69,7 +69,7 @@ title: API Evangelist
 	<a name="api-lifecycle"></a>
 	<div class="content">
 	<header>
-		<h1>API Lifecycle</h1>
+		<h2>API Lifecycle</h2>
 	</header>
 	<p>These are the stops in a modern API lifecycle that I keep track of trying to understand how APIs are being delivered across the space:</p>
 	<table cellpadding="0" cellspacing="0" border="0" width="100%">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11600883/55482057-fffb1580-5623-11e9-9252-4745ad37081f.png)

The two headings on the API Lifecycle page look slighty cutoff. This PR fixes this by using h2 instead of h1. All the other headings on the same level are h2 too, so this is consistent with the rest of the page.